### PR TITLE
Refactor websocket api

### DIFF
--- a/src/main/resources/api/commons.yml
+++ b/src/main/resources/api/commons.yml
@@ -34,7 +34,7 @@ components:
           description: The URI of the avatar image of the user
         status:
           type: string
-          description: The user's active status (online, idle, dnd, offline)
+          description: The user's active status (online, idle, do_not_disturb, offline)
 
     Message:
       type: object

--- a/src/main/resources/api/websocket.yml
+++ b/src/main/resources/api/websocket.yml
@@ -9,6 +9,8 @@ servers:
     url: ws://localhost:8080/ws
     protocol: ws
     description: DiscHard WebSocket server with STOMP support
+    security:
+      - bearerAuth: [ ]
 
 channels:
   /app/messages:
@@ -30,7 +32,7 @@ channels:
       conversationId:
         description: ID of the conversation
         schema:
-          type: string
+          type: number
     subscribe:
       summary: Receive new messages in a specific conversation
       operationId: receiveConversationMessages
@@ -46,7 +48,7 @@ channels:
 
   /app/typing:
     publish:
-      summary: Send typing indicator
+      summary: Send a typing indicator for a conversation
       operationId: sendTypingIndicator
       message:
         $ref: '#/components/messages/TypingIndicator'
@@ -56,7 +58,7 @@ channels:
       conversationId:
         description: ID of the conversation
         schema:
-          type: string
+          type: number
     subscribe:
       summary: Receive typing indicators for a specific conversation
       operationId: receiveTypingIndicators
@@ -88,13 +90,9 @@ channels:
           oneOf:
             - $ref: '#/components/messages/ConversationCreated/payload'
             - $ref: '#/components/messages/ConversationUpdated/payload'
-            - $ref: '#/components/messages/MembershipChanged/payload'
-          discriminator:
-            propertyName: eventType
-            mapping:
-              conversation_created: '#/components/messages/ConversationCreated/payload'
-              conversation_updated: '#/components/messages/ConversationUpdated/payload'
-              membership_changed: '#/components/messages/MembershipChanged/payload'
+            - $ref: '#/components/messages/MembersAdded/payload'
+            - $ref: '#/components/messages/MembersRemoved/payload'
+          discriminator: 'eventType'
 
   /user/queue/notifications:
     subscribe:
@@ -105,21 +103,6 @@ channels:
 
 components:
   messages:
-    ConnectionRequest:
-      name: ConnectionRequest
-      title: WebSocket Connection Request
-      summary: Authentication request for WebSocket connection
-      contentType: application/json
-      payload:
-        type: object
-        properties:
-          token:
-            type: string
-            description: JWT token for authentication
-        required:
-          - token
-
-
     StartConversation:
       name: StartConversation
       title: Start New Conversation Request
@@ -225,7 +208,7 @@ components:
         properties:
           status:
             type: string
-            enum: [ online, offline, away, dnd ]
+            enum: [ online, offline, away, do_not_disturb ]
             description: New status of the user
         required:
           - status
@@ -271,8 +254,8 @@ components:
             type: string
             description: Name of the group (only for group conversations)
           createdBy:
-            $ref: 'commons.yml#/components/schemas/User'
-            description: User who created the conversation
+            $ref: 'commons.yml#/components/schemas/Member'
+            description: Member who created the conversation
           members:
             type: array
             items:
@@ -285,9 +268,6 @@ components:
         required:
           - eventType
           - conversationId
-          - type
-          - createdBy
-          - members
           - timestamp
 
     ConversationUpdated:
@@ -312,8 +292,8 @@ components:
             type: string
             description: New description of the group
           updatedBy:
-            $ref: 'commons.yml#/components/schemas/User'
-            description: User who updated the conversation
+            $ref: 'commons.yml#/components/schemas/Member'
+            description: Member who updated the conversation
           timestamp:
             type: string
             format: date-time
@@ -321,45 +301,6 @@ components:
         required:
           - eventType
           - conversationId
-          - updatedBy
-          - timestamp
-
-    MembershipChanged:
-      name: MembershipChanged
-      title: Conversation Membership Changed
-      summary: Members of a conversation have changed
-      contentType: application/json
-      payload:
-        type: object
-        properties:
-          eventType:
-            type: string
-            enum: [ membership_changed ]
-            description: Type of event for discrimination
-          conversationId:
-            type: number
-            description: ID of the conversation
-          changeType:
-            type: string
-            enum: [ added, removed ]
-            description: Type of membership change
-          users:
-            type: array
-            items:
-              $ref: 'commons.yml#/components/schemas/User'
-            description: List of Users who were added or removed
-          changedBy:
-            $ref: 'commons.yml#/components/schemas/User'
-            description: User who made the change (null if user left voluntarily)
-          timestamp:
-            type: string
-            format: date-time
-            description: Time when membership changed
-        required:
-          - eventType
-          - conversationId
-          - changeType
-          - users
           - timestamp
 
     UserNotification:
@@ -402,6 +343,70 @@ components:
           - id
           - type
           - content
+          - timestamp
+
+    MembersAdded:
+      name: MembersAdded
+      title: Members Added to Conversation
+      summary: New members added to a conversation
+      contentType: application/json
+      payload:
+        type: object
+        properties:
+          eventType:
+            type: string
+            enum: [ members_added ]
+            description: Type of event for discrimination
+          conversationId:
+            type: number
+            description: ID of the conversation
+          members:
+            type: array
+            items:
+              $ref: 'commons.yml#/components/schemas/Member'
+            description: List of complete Member objects that were added
+          addedByMemberId:
+            type: number
+            description: ID of the member who added the new members
+          timestamp:
+            type: string
+            format: date-time
+            description: Time when members were added
+        required:
+          - eventType
+          - conversationId
+          - timestamp
+
+    MembersRemoved:
+      name: MembersRemoved
+      title: Members Removed from Conversation
+      summary: Members removed from a conversation
+      contentType: application/json
+      payload:
+        type: object
+        properties:
+          eventType:
+            type: string
+            enum: [ members_removed ]
+            description: Type of event for discrimination
+          conversationId:
+            type: number
+            description: ID of the conversation
+          memberIds:
+            type: array
+            items:
+              type: number
+            description: List of member IDs that were removed
+          removedByMemberId:
+            type: number
+            description: ID of the member who removed the members (null if member left voluntarily)
+          timestamp:
+            type: string
+            format: date-time
+            description: Time when members were removed
+        required:
+          - eventType
+          - conversationId
           - timestamp
 
   securitySchemes:

--- a/src/main/resources/api/websocket.yml
+++ b/src/main/resources/api/websocket.yml
@@ -11,13 +11,6 @@ servers:
     description: DiscHard WebSocket server with STOMP support
 
 channels:
-  /app/connect:
-    publish:
-      summary: Connect and authenticate to the WebSocket server
-      operationId: connectWebSocket
-      message:
-        $ref: '#/components/messages/ConnectionRequest'
-
   /app/messages:
     publish:
       summary: Send a new message to an existing conversation
@@ -89,10 +82,19 @@ channels:
       summary: Receive updates about conversations (new, modified, members)
       operationId: receiveConversationsUpdates
       message:
-        oneOf:
-          - $ref: '#/components/messages/ConversationCreated'
-          - $ref: '#/components/messages/ConversationUpdated'
-          - $ref: '#/components/messages/MembershipChanged'
+        name: ConversationEvent
+        contentType: application/json
+        payload:
+          oneOf:
+            - $ref: '#/components/messages/ConversationCreated/payload'
+            - $ref: '#/components/messages/ConversationUpdated/payload'
+            - $ref: '#/components/messages/MembershipChanged/payload'
+          discriminator:
+            propertyName: eventType
+            mapping:
+              conversation_created: '#/components/messages/ConversationCreated/payload'
+              conversation_updated: '#/components/messages/ConversationUpdated/payload'
+              membership_changed: '#/components/messages/MembershipChanged/payload'
 
   /user/queue/notifications:
     subscribe:
@@ -254,6 +256,10 @@ components:
       payload:
         type: object
         properties:
+          eventType:
+            type: string
+            enum: [ conversation_created ]
+            description: Type of event for discrimination
           conversationId:
             type: number
             description: ID of the new conversation
@@ -277,6 +283,7 @@ components:
             format: date-time
             description: Time when conversation was created
         required:
+          - eventType
           - conversationId
           - type
           - createdBy
@@ -291,6 +298,10 @@ components:
       payload:
         type: object
         properties:
+          eventType:
+            type: string
+            enum: [ conversation_updated ]
+            description: Type of event for discrimination
           conversationId:
             type: number
             description: ID of the conversation
@@ -308,6 +319,7 @@ components:
             format: date-time
             description: Time when conversation was updated
         required:
+          - eventType
           - conversationId
           - updatedBy
           - timestamp
@@ -320,10 +332,14 @@ components:
       payload:
         type: object
         properties:
+          eventType:
+            type: string
+            enum: [ membership_changed ]
+            description: Type of event for discrimination
           conversationId:
             type: number
             description: ID of the conversation
-          type:
+          changeType:
             type: string
             enum: [ added, removed ]
             description: Type of membership change
@@ -340,8 +356,9 @@ components:
             format: date-time
             description: Time when membership changed
         required:
+          - eventType
           - conversationId
-          - type
+          - changeType
           - users
           - timestamp
 

--- a/src/main/resources/api/websocket.yml
+++ b/src/main/resources/api/websocket.yml
@@ -399,6 +399,7 @@ components:
             description: List of member IDs that were removed
           removedByMemberId:
             type: number
+            nullable: true
             description: ID of the member who removed the members (null if member left voluntarily)
           timestamp:
             type: string

--- a/src/main/resources/api/websocket.yml
+++ b/src/main/resources/api/websocket.yml
@@ -253,9 +253,9 @@ components:
           name:
             type: string
             description: Name of the group (only for group conversations)
-          createdBy:
-            $ref: 'commons.yml#/components/schemas/Member'
-            description: Member who created the conversation
+          createdByMemberId:
+            type: number
+            description: ID of the member who created the conversation
           members:
             type: array
             items:
@@ -291,9 +291,9 @@ components:
           description:
             type: string
             description: New description of the group
-          updatedBy:
-            $ref: 'commons.yml#/components/schemas/Member'
-            description: Member who updated the conversation
+          updatedByMemberId:
+            type: number
+            description: ID of the member who updated the conversation
           timestamp:
             type: string
             format: date-time


### PR DESCRIPTION
This pull request introduces several updates to the WebSocket API and its components, focusing on improving consistency, enhancing clarity, and updating the data model. Key changes include refining status descriptions, adding security requirements, restructuring payloads for better discrimination, and introducing new message types for member-related events.

### API Improvements

* Updated the `status` field description in `commons.yml` to replace "dnd" with "do_not_disturb" for consistency.
* Added a `bearerAuth` security requirement to the WebSocket server configuration in `websocket.yml`.

### Data Model Updates

* Changed the `conversationId` type from `string` to `number` in multiple WebSocket channels for consistency. [[1]](diffhunk://#diff-e86e2d4cfa72f32840aa4633375659708b3757779a0c2c3a9c867ca1cc9be213L40-R35) [[2]](diffhunk://#diff-e86e2d4cfa72f32840aa4633375659708b3757779a0c2c3a9c867ca1cc9be213L66-R61)
* Replaced `createdBy` and `updatedBy` fields in conversation payloads with `createdByMemberId` and `updatedByMemberId` to use member IDs instead of full user objects. [[1]](diffhunk://#diff-e86e2d4cfa72f32840aa4633375659708b3757779a0c2c3a9c867ca1cc9be213L267-R258) [[2]](diffhunk://#diff-e86e2d4cfa72f32840aa4633375659708b3757779a0c2c3a9c867ca1cc9be213L303-L345)

### Payload Restructuring

* Introduced an `eventType` field in conversation-related payloads to enable discrimination between different event types. [[1]](diffhunk://#diff-e86e2d4cfa72f32840aa4633375659708b3757779a0c2c3a9c867ca1cc9be213R242-R245) [[2]](diffhunk://#diff-e86e2d4cfa72f32840aa4633375659708b3757779a0c2c3a9c867ca1cc9be213R269-L283) [[3]](diffhunk://#diff-e86e2d4cfa72f32840aa4633375659708b3757779a0c2c3a9c867ca1cc9be213R281-R284)
* Updated the `receiveConversationsUpdates` channel to include more granular event types like `MembersAdded` and `MembersRemoved`, with references to their payloads.

### New Message Types

* Added `MembersAdded` and `MembersRemoved` message types to handle events for adding or removing members in conversations, including details like member IDs and timestamps.